### PR TITLE
feat: add custom error handling to clearly distinguish proxy-specific errors from those returned by the target API

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,10 @@ Proxy a request to the specified URL.
 **Response:**
 The response from the target URL with CORS headers added.
 
-
 Returns API information and usage examples.
+
+> [!IMPORTANT]
+> If there is any error in the request, the server will return a **999** status code. This is a custom status code used to indicate that the request could not be processed due to an error. The response will include an `error` field and a `details` field with details about the issue. This is to avoid confusion with standard HTTP status codes and to provide a clear indication of errors specific to this proxy server and not the target API.
 
 ## 🔧 Configuration
 

--- a/index.js
+++ b/index.js
@@ -144,7 +144,7 @@ app.post('/request', async (req, res) => {
     } catch (error) {
         console.error('Request processing error:', error);
         res.status(999).json({
-            error: 'Network Connect Timeout Error',
+            error: 'Proxy Error: Whoops. Something went wrong while processing yer request! Are you sure the URL is correct? or that the site has a port we can sale to?',
             success: false,
             details: error.message,
         });

--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ app.post('/request', async (req, res) => {
         proxyReq.on('error', error => {
             console.error('Proxy request error:', error);
             if (!res.headersSent) {
-                res.status(500).json({
+                res.status(999).json({
                     error: 'Failed to complete request',
                     success: false,
                     details: error.message,
@@ -143,8 +143,8 @@ app.post('/request', async (req, res) => {
         proxyReq.end();
     } catch (error) {
         console.error('Request processing error:', error);
-        res.status(500).json({
-            error: 'Internal server error',
+        res.status(999).json({
+            error: 'Network Connect Timeout Error',
             success: false,
             details: error.message,
         });

--- a/openapi.yml
+++ b/openapi.yml
@@ -169,8 +169,8 @@ paths:
                   value:
                     error: "Invalid URL provided"
                     success: false
-        '500':
-          description: Internal server error or proxy request failed
+        '999':
+          description: Internal server error or proxy request failed. This is a custom status code used to indicate that the request could not be processed due to an error and is not a standard HTTP status code to avoid confusion with errors from the target API.
           content:
             application/json:
               schema:


### PR DESCRIPTION
This pull request introduces a custom error handling approach for the proxy server by replacing standard HTTP error codes with a custom status code (999). This change aims to clearly distinguish proxy-specific errors from errors originating from the target API, both in server responses and documentation.

**Error handling changes:**

* Updated the error response code from `500` to `999` in the proxy route in `index.js`, including both proxy request errors and general request processing errors. The error messages have also been clarified to indicate proxy-specific issues. [[1]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L120-R120) [[2]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L146-R147)
* Updated the OpenAPI specification in `openapi.yml` to document the new `999` status code, explaining its purpose and usage for proxy errors.

**Documentation updates:**

* Added an explanation to `README.md` about the use of the custom `999` status code, describing its intent and the structure of the error response.